### PR TITLE
client-ffi + dart-bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbindgen"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104ca409bbff8293739438c71820a2606111b5f8f81835536dc673dfd807369e"
+dependencies = [
+ "clap 2.33.1",
+ "heck",
+ "log",
+ "proc-macro2",
+ "quote 1.0.6",
+ "serde",
+ "serde_json",
+ "syn 1.0.30",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +704,17 @@ dependencies = [
  "textwrap",
  "thiserror",
  "utils-identity",
+]
+
+[[package]]
+name = "client-ffi"
+version = "0.1.0"
+dependencies = [
+ "cbindgen",
+ "client-identity",
+ "ffi_helpers",
+ "image",
+ "keybase-keystore",
 ]
 
 [[package]]
@@ -977,6 +1006,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
+dependencies = [
+ "adler32",
+ "byteorder",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1197,17 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da54a593b34c71b889ee45f5b5bb900c74148c5f7f8c6a9479ee7899f69603c"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ffi_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5db858a1f8749e81b22cb9e10a5412c9775441a53c4bd1d1f28531edc843"
+dependencies = [
+ "failure",
+ "failure_derive",
  "libc",
 ]
 
@@ -1996,6 +2046,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ed2ada878397b045454ac7cfb011d73132c59f31a955d230bd1f1c2e68eb4a"
+dependencies = [
+ "byteorder",
+ "num-iter",
+ "num-rational",
+ "num-traits 0.2.11",
+ "png",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,6 +2103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
  "autocfg 1.0.0",
+]
+
+[[package]]
+name = "inflate"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
+dependencies = [
+ "adler32",
 ]
 
 [[package]]
@@ -3311,6 +3383,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-integer",
+ "num-traits 0.2.11",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3934,6 +4017,18 @@ name = "platforms"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
+
+[[package]]
+name = "png"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef859a23054bbfee7811284275ae522f0434a3c8e7f4b74bd4a35ae7e1c4a283"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "deflate",
+ "inflate",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["bin/cli", "bin/node", "client", "keystore", "pallet", "utils"]
+members = ["bin/cli", "bin/node", "client", "client-ffi", "keystore", "pallet", "utils"]
 
 [patch.crates-io]
 substrate-subxt = { git = "https://github.com/paritytech/substrate-subxt" }

--- a/client-ffi/Cargo.toml
+++ b/client-ffi/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "client-ffi"
+version = "0.1.0"
+authors = ["David Craven <david@craven.ch>, Shady Khalifa <shekohex@gmail.com>, Amar Singh <asinghchrony@protonmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "staticlib"]
+
+[dependencies]
+ffi_helpers = "0.1.0"
+image = { version = "0.22.4", default-features = false, features = ["png_codec"] }
+client = { package = "client-identity", path = "../client" }
+keystore = { package = "keybase-keystore", path = "../keystore" }
+
+[build-dependencies]
+cbindgen = "0.14.0"

--- a/client-ffi/src/lib.rs
+++ b/client-ffi/src/lib.rs
@@ -1,0 +1,243 @@
+#![allow(clippy::missing_safety_doc)]
+
+use ffi_helpers::null_pointer_check;
+use image::{DynamicImage, ImageOutputFormat};
+use keystore::KeyStore;
+use std::{
+    ffi::{CStr, CString},
+    os::raw,
+    path::Path,
+};
+
+macro_rules! error {
+    ($result:expr) => {
+        error!($result, 0);
+    };
+    ($result:expr, $error:expr) => {
+        match $result {
+            Ok(value) => value,
+            Err(e) => {
+                ffi_helpers::update_last_error(e);
+                return $error;
+            }
+        }
+    };
+}
+
+macro_rules! cstr {
+    ($ptr:expr) => {
+        cstr!($ptr, 0);
+    };
+    ($ptr:expr, $error:expr) => {
+        error!(CStr::from_ptr($ptr).to_str(), $error)
+    };
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn last_error_length() -> i32 {
+    ffi_helpers::error_handling::last_error_length()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn error_message_utf8(buf: *mut raw::c_char, length: i32) -> i32 {
+    ffi_helpers::error_handling::error_message_utf8(buf, length)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn keystore_new() -> *mut raw::c_void {
+    let keystore = KeyStore::default();
+    let boxed_keystore = Box::new(keystore);
+    Box::into_raw(boxed_keystore) as *mut _
+}
+
+// #[no_mangle]
+// pub unsafe extern "C" fn keystore_from_keyfile(
+//     path: *const raw::c_char,
+// ) -> *mut raw::c_void {
+//     let path = cstr!(path, std::ptr::null_mut());
+//     let path = Path::new(path).to_path_buf();
+//     let keystore = Keystore::new(path);
+//     let boxed_keystore = Box::new(keystore);
+//     Box::into_raw(boxed_keystore) as *mut _
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn keystore_destroy(keystore: *mut raw::c_void) {
+//     null_pointer_check!(keystore);
+//     Box::from_raw(keystore as *mut Keystore);
+// }
+
+// pub const KEYSTORE_UNINITIALIZED: i32 = 1;
+// pub const KEYSTORE_LOCKED: i32 = 2;
+// pub const KEYSTORE_UNLOCKED: i32 = 3;
+
+// #[no_mangle]
+// pub unsafe extern "C" fn keystore_status(keystore: *const raw::c_void) -> i32 {
+//     null_pointer_check!(keystore);
+//     let keystore = &*(keystore as *const Keystore);
+//     match keystore.status() {
+//         Status::Uninitialized => KEYSTORE_UNINITIALIZED,
+//         Status::Locked => KEYSTORE_LOCKED,
+//         Status::Unlocked => KEYSTORE_UNLOCKED,
+//     }
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn keystore_generate(
+//     keystore: *mut raw::c_void,
+//     password: *const raw::c_char,
+// ) -> i32 {
+//     null_pointer_check!(keystore);
+//     let keystore = &mut *(keystore as *mut Keystore);
+//     let password = cstr!(password);
+//     let result = keystore.generate(password);
+//     error!(result);
+//     1
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn keystore_import(
+//     keystore: *mut raw::c_void,
+//     phrase: *const raw::c_char,
+//     password: *const raw::c_char,
+// ) -> i32 {
+//     null_pointer_check!(keystore);
+//     let keystore = &mut *(keystore as *mut Keystore);
+//     let phrase = cstr!(phrase);
+//     let password = cstr!(password);
+//     let result = keystore.import(phrase, password);
+//     error!(result);
+//     1
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn keystore_unlock(
+//     keystore: *mut raw::c_void,
+//     password: *const raw::c_char,
+// ) -> i32 {
+//     null_pointer_check!(keystore);
+//     let keystore = &mut *(keystore as *mut Keystore);
+//     let password = cstr!(password);
+//     let result = keystore.unlock(password);
+//     error!(result);
+//     1
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn keystore_lock(keystore: *mut raw::c_void) -> i32 {
+//     null_pointer_check!(keystore);
+//     let keystore = &mut *(keystore as *mut Keystore);
+//     keystore.lock();
+//     1
+// }
+
+// pub const KEYSTORE_PAPER_BACKUP: i32 = 1;
+// pub const KEYSTORE_NO_PAPER_BACKUP: i32 = 2;
+
+// #[no_mangle]
+// pub unsafe extern "C" fn keystore_paper_backup(
+//     keystore: *mut raw::c_void,
+// ) -> i32 {
+//     null_pointer_check!(keystore);
+//     let keystore = &mut *(keystore as *mut Keystore);
+//     let result = keystore.paper_backup();
+//     if error!(result) {
+//         KEYSTORE_PAPER_BACKUP
+//     } else {
+//         KEYSTORE_NO_PAPER_BACKUP
+//     }
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn keystore_set_paper_backup(
+//     keystore: *mut raw::c_void,
+// ) -> i32 {
+//     null_pointer_check!(keystore);
+//     let keystore = &mut *(keystore as *mut Keystore);
+//     let result = keystore.set_paper_backup();
+//     error!(result);
+//     1
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn keystore_phrase(
+//     keystore: *mut raw::c_void,
+//     password: *const raw::c_char,
+// ) -> *const raw::c_char {
+//     null_pointer_check!(keystore);
+//     let keystore = &mut *(keystore as *mut Keystore);
+//     let password = cstr!(password, std::ptr::null());
+//     let result = keystore.phrase(password);
+//     let cstr = error!(result, std::ptr::null());
+//     let cstr = error!(CString::new(cstr), std::ptr::null());
+//     cstr.into_raw()
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn phrase_destroy(phrase: *mut raw::c_char) {
+//     CString::from_raw(phrase);
+// }
+
+// #[repr(C)]
+// struct Account {
+//     pub name: *const raw::c_char,
+//     pub ss58: *const raw::c_char,
+//     pub identicon_ptr: *const u8,
+//     pub identicon_len: i32,
+//     pub qrcode_ptr: *const u8,
+//     pub qrcode_len: i32,
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn keystore_account(
+//     keystore: *mut raw::c_void,
+// ) -> *mut raw::c_void {
+//     null_pointer_check!(keystore, std::ptr::null_mut());
+//     let keystore = &mut *(keystore as *mut Keystore);
+//     let key = error!(keystore.get_key(Some(0)), std::ptr::null_mut());
+//     let name = error!(CString::new("/"), std::ptr::null_mut());
+//     let ss58 = error!(CString::new(key.ss58()), std::ptr::null_mut());
+//     let identicon_rgba =
+//         DynamicImage::ImageRgba8(error!(key.identicon(), std::ptr::null_mut()));
+//     let mut identicon = Vec::new();
+//     error!(
+//         identicon_rgba.write_to(&mut identicon, ImageOutputFormat::PNG),
+//         std::ptr::null_mut()
+//     );
+//     let identicon = identicon.into_boxed_slice();
+//     let qrcode_rgba =
+//         DynamicImage::ImageRgba8(error!(key.qrcode(), std::ptr::null_mut()));
+//     let mut qrcode = Vec::new();
+//     error!(
+//         qrcode_rgba.write_to(&mut qrcode, ImageOutputFormat::PNG),
+//         std::ptr::null_mut()
+//     );
+//     let qrcode = qrcode.into_boxed_slice();
+//     let account = Box::new(Account {
+//         name: name.into_raw(),
+//         ss58: ss58.into_raw(),
+//         identicon_ptr: identicon.as_ptr(),
+//         identicon_len: identicon.len() as i32,
+//         qrcode_ptr: qrcode.as_ptr(),
+//         qrcode_len: qrcode.len() as i32,
+//     });
+//     std::mem::forget(identicon);
+//     std::mem::forget(qrcode);
+//     Box::into_raw(account) as *mut raw::c_void
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn account_destroy(account: *mut raw::c_void) {
+//     null_pointer_check!(account);
+//     let account = Box::from_raw(account as *mut Account);
+//     let _name = CString::from_raw(account.name as *mut raw::c_char);
+//     let _ss58 = CString::from_raw(account.ss58 as *mut raw::c_char);
+//     let _identicon = Box::from_raw(std::slice::from_raw_parts_mut(
+//         account.identicon_ptr as *mut u8,
+//         account.identicon_len as usize,
+//     ));
+//     let _qrcode = Box::from_raw(std::slice::from_raw_parts_mut(
+//         account.qrcode_ptr as *mut u8,
+//         account.qrcode_len as usize,
+//     ));
+// }

--- a/keystore/src/keystore.rs
+++ b/keystore/src/keystore.rs
@@ -165,7 +165,9 @@ pub struct KeyStore {
 
 impl Default for KeyStore {
     fn default() -> KeyStore {
-        KeyStore::new("tmp/keystore")
+        let mut path = std::env::temp_dir();
+        path.push("keystore");
+        KeyStore::new(path)
     }
 }
 

--- a/keystore/src/keystore.rs
+++ b/keystore/src/keystore.rs
@@ -163,6 +163,12 @@ pub struct KeyStore {
     pdk: SecretFile,
 }
 
+impl Default for KeyStore {
+    fn default() -> KeyStore {
+        KeyStore::new("tmp/keystore")
+    }
+}
+
 impl KeyStore {
     /// Creates a new keystore.
     pub fn new<T: AsRef<Path>>(path: T) -> Self {


### PR DESCRIPTION
The goal of this PR is to get an example working that uses `dart-bindgen` with the client code in this repo.

It was started by copying and pasting some code from `sunshine-flutter/native/keystore-ffi` and adding a `Default` implementation to the local keystore to get `keystore_new` working.

David has mentioned that `bin/cli` shows how to use the public API cc @shekohex 