### PR TITLE
few small things

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7186,6 +7186,7 @@ version = "0.1.0"
 dependencies = [
  "libipld",
  "parity-scale-codec",
+ "serde",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Substrate Identity Module
+# Sunshine Identity Module
+
+
+implementation of [Keybase Local Key Security](https://book.keybase.io/docs/crypto/local-key-security) on substrate, using [ipfs-rust/ipfs-embed](https://github.com/ipfs-rust/ipfs-embed)
 
 ## Build
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -9,8 +9,10 @@ default = ["std"]
 std = [
     "codec/std",
     "libipld",
+    "serde",
 ]
 
 [dependencies]
 codec = { version = "1.3.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
 libipld = { version = "0.3.0", default-features = false, optional = true }
+serde = { version = "1.0.101", features = ["derive"], optional = true }


### PR DESCRIPTION
- [x] serde `Serialize` and `Deserialize` impls for `CidBytes` because I plan to use this in the genesis on the node and the node's genesis storage requires these bounds

- [x] change title on README to sunshine-identity and add description:

### description added to top of README

implementation of [Keybase Local Key Security](https://book.keybase.io/docs/crypto/local-key-security) on substrate, using [ipfs-embed](https://github.com/ipfs-rust/ipfs-embed)